### PR TITLE
Fix typo in documentation

### DIFF
--- a/epkg.org
+++ b/epkg.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Epkg: (epkg).
 #+TEXINFO_DIR_DESC: Browse the Emacsmirror's database
-#+SUBTITLE: for version 3.0.0 (v3.0.0-32-g432312b+1)
+#+SUBTITLE: for version 3.0.0 (v3.0.0-33-g81b1a33+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -18,7 +18,7 @@ With Epkg you can browse the Emacsmirror package database using an
 interface similar to that of ~package.el~.
 
 #+TEXINFO: @noindent
-This manual is for Epkg version 3.0.0 (v3.0.0-32-g432312b+1).
+This manual is for Epkg version 3.0.0 (v3.0.0-33-g81b1a33+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2016-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -77,7 +77,7 @@ announced [fn:3].
 * Installation
 
 Epkg is available from Melpa and Melpa-Stable.  To install it and its
-dependencies run ~M-x install-package RET epkg RET~.
+dependencies run ~M-x package-install RET epkg RET~.
 
 The Epkg database is stored in an SQLite database, which it accesses
 using the EmacSQL package.

--- a/epkg.texi
+++ b/epkg.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Epkg User Manual
-@subtitle for version 3.0.0 (v3.0.0-32-g432312b+1)
+@subtitle for version 3.0.0 (v3.0.0-33-g81b1a33+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -47,7 +47,7 @@ With Epkg you can browse the Emacsmirror package database using an
 interface similar to that of @code{package.el}.
 
 @noindent
-This manual is for Epkg version 3.0.0 (v3.0.0-32-g432312b+1).
+This manual is for Epkg version 3.0.0 (v3.0.0-33-g81b1a33+1).
 
 @quotation
 Copyright (C) 2016-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -115,7 +115,7 @@ announced @footnote{@uref{https://emacsair.me/2016/04/16/re-introducing-the-emac
 @chapter Installation
 
 Epkg is available from Melpa and Melpa-Stable.  To install it and its
-dependencies run @code{M-x install-package RET epkg RET}.
+dependencies run @code{M-x package-install RET epkg RET}.
 
 The Epkg database is stored in an SQLite database, which it accesses
 using the EmacSQL package.


### PR DESCRIPTION
I've updated both the `org` source (?) and the `texi` intermediary output.