### PR TITLE
Require subr-x at compile time

### DIFF
--- a/epkg.el
+++ b/epkg.el
@@ -35,9 +35,11 @@
 
 (require 'dash)
 (require 'seq)
-(require 'subr-x)
 
 (require 'closql)
+
+(eval-when-compile
+  (require 'subr-x))
 
 ;;; Options
 


### PR DESCRIPTION
if/when-let are macros that can be expanded at compile time rather
than run time