### PR TITLE
Require subr-x for compilation explicitly everywhere it's needed

### DIFF
--- a/epkg-desc.el
+++ b/epkg-desc.el
@@ -24,6 +24,9 @@
 (require 'epkg)
 (require 'find-func)
 
+(eval-when-compile
+  (require 'subr-x))                    ; `if-let'
+
 ;;; Options
 
 (defconst epkg--custom-slot-choices

--- a/epkg-list.el
+++ b/epkg-list.el
@@ -24,6 +24,9 @@
 (require 'epkg)
 (require 'epkg-desc)
 
+(eval-when-compile
+  (require 'subr-x))                    ; `if-let'
+
 ;;; Options
 
 (defcustom epkg-list-exclude-types '(shelved)

--- a/epkg-org.el
+++ b/epkg-org.el
@@ -28,6 +28,9 @@
 
 (require 'epkg)
 
+(eval-when-compile
+  (require 'subr-x))                    ; `if-let', `when-let'
+
 (defmacro epkg-with-org-header (header &rest body)
   (declare (indent defun))
   `(when-let (rows (progn ,@body))


### PR DESCRIPTION
Honestly, I'm not sure those SILENCIO hacks are such a great idea in
general. Also, in this particular case, I don't see any deprecation of
`if-let' on 26.2, was it changed?