### PR TITLE
Fix epkg-list-matching-packages pattern argument

### DIFF
--- a/epkg-list.el
+++ b/epkg-list.el
@@ -116,7 +116,10 @@ is used."
 
 ;;;###autoload
 (defun epkg-list-matching-packages (pattern &optional all)
-  "Display a list of packages whose summaries match REGEXP.
+  "Display a list of packages whose summaries match PATTERN.
+PATTERN should be a string with SQLite LIKE pattern syntax.
+If it does not contain any wildcards ('%' or '_'), it will be
+surrounded by '%' automatically.
 
 Respect option `epkg-list-exclude-types' unless a prefix argument
 is used."

--- a/epkg-list.el
+++ b/epkg-list.el
@@ -127,7 +127,7 @@ is used."
                          (like name $s2))
               :and class :in $v3]
              (epkg--list-columns-vector)
-             (intern (if (string-match-p "%_" pattern)
+             (intern (if (string-match-p "[%_]" pattern)
                          pattern
                        (concat "%" pattern "%")))
              (epkg--list-where-class-in all))))

--- a/epkg-list.el
+++ b/epkg-list.el
@@ -116,7 +116,7 @@ is used."
 
 ;;;###autoload
 (defun epkg-list-matching-packages (pattern &optional all)
-  "Display a list of packages whose summaries match PATTERN.
+  "Display a list of packages whose name or summary matches PATTERN.
 PATTERN should be a string with SQLite LIKE pattern syntax.
 If it does not contain any wildcards ('%' or '_'), it will be
 surrounded by '%' automatically.

--- a/epkg.org
+++ b/epkg.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Epkg: (epkg).
 #+TEXINFO_DIR_DESC: Browse the Emacsmirror's database
-#+SUBTITLE: for version 3.2.1
+#+SUBTITLE: for version 3.2.1 (v3.2.1-7-gdc08824+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ With Epkg you can browse the Emacsmirror package database using an
 interface similar to that of ~package.el~.
 
 #+TEXINFO: @noindent
-This manual is for Epkg version 3.2.1.
+This manual is for Epkg version 3.2.1 (v3.2.1-7-gdc08824+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2016-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -181,7 +181,7 @@ about the package at point in another buffer.
 - Command: epkg-list-matching-packages
 
   This command displays a list of packages whose summaries match a
-  regular expression, which is read in the minibuffer.
+  SQLite LIKE pattern, which is read in the minibuffer.
 
 - Command: epkg-list-keyworded-packages
 

--- a/epkg.org
+++ b/epkg.org
@@ -180,8 +180,8 @@ about the package at point in another buffer.
 
 - Command: epkg-list-matching-packages
 
-  This command displays a list of packages whose summaries match a
-  SQLite LIKE pattern, which is read in the minibuffer.
+  This command displays a list of packages whose name or summary
+  matches a SQLite LIKE pattern, which is read in the minibuffer.
 
 - Command: epkg-list-keyworded-packages
 

--- a/epkg.texi
+++ b/epkg.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Epkg User Manual
-@subtitle for version 3.2.1
+@subtitle for version 3.2.1 (v3.2.1-7-gdc08824+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ With Epkg you can browse the Emacsmirror package database using an
 interface similar to that of @code{package.el}.
 
 @noindent
-This manual is for Epkg version 3.2.1.
+This manual is for Epkg version 3.2.1 (v3.2.1-7-gdc08824+1).
 
 @quotation
 Copyright (C) 2016-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -242,7 +242,7 @@ shelved) packages.
 @deffn Command epkg-list-matching-packages
 
 This command displays a list of packages whose summaries match a
-regular expression, which is read in the minibuffer.
+SQLite LIKE pattern, which is read in the minibuffer.
 @end deffn
 
 @cindex epkg-list-keyworded-packages

--- a/epkg.texi
+++ b/epkg.texi
@@ -241,8 +241,8 @@ shelved) packages.
 @cindex epkg-list-matching-packages
 @deffn Command epkg-list-matching-packages
 
-This command displays a list of packages whose summaries match a
-SQLite LIKE pattern, which is read in the minibuffer.
+This command displays a list of packages whose name or summary
+matches a SQLite LIKE pattern, which is read in the minibuffer.
 @end deffn
 
 @cindex epkg-list-keyworded-packages


### PR DESCRIPTION
- fix incorrect regexp matching

- fix the doc string to match the behaviour and argument name