### PR TITLE
epkg-read-package: Improve default guessing

### DIFF
--- a/epkg.el
+++ b/epkg.el
@@ -424,7 +424,8 @@ be used to provide an even better default choice, if possible."
               (looking-at "^[ \t]*| \\([^ ]+\\)")
               (match-string 1))
          (--when-let (symbol-at-point)
-           (symbol-name it))))))
+           (string-trim-right (string-trim-left (symbol-name it) ".*/")
+                              "\\..*"))))))
 
 ;;; _
 (provide 'epkg)


### PR DESCRIPTION
Often (e.g., Elisp comments, Magit submodule lists), 'symbol-at-point'
returns a path or URL. Chop off the part before last slash and after
any dot in the remaining part (the extension). (Package names
containing slashes or dots don't seem to occur, so this is safe.)

The trimming order is important, so 'string-trim' doesn't fit the
bill (and wouldn't save any funcalls, either).