### PR TITLE
Fixed infinite loop issue with epkg-db and epkg-update

### DIFF
--- a/lisp/epkg.el
+++ b/lisp/epkg.el
@@ -200,11 +200,11 @@ database."
   (interactive)
   (when epkg--db-connection
     (emacsql-close epkg--db-connection))
-  (prog1 (epkg-db)
-    (let ((default-directory epkg-repository))
-      (message "Pulling Epkg database...")
-      (epkg--call-git "pull" "--no-recurse-submodules" "origin" "master")
-      (message "Pulling Epkg database...done"))))
+  (let ((default-directory epkg-repository))
+    (message "Pulling Epkg database...")
+    (epkg--call-git "pull" "--no-recurse-submodules" "origin" "master")
+    (message "Pulling Epkg database...done"))
+  (epkg-db))
 
 (defvar magit-process-popup-time)
 (declare-function magit-call-git "magit-process" (&rest args))


### PR DESCRIPTION
`epkg-db-version` incremented with https://github.com/emacscollective/epkg/commit/2ebb5e5f7b69a580b586de1a0d112e3fa03e0813, but `epkg-update` doesn't work as expected and asks "The installed `epkg' version requires a new database scheme.  Update database now?" endlessly.